### PR TITLE
fix: correct grammar and add missing alt attributes in English pages

### DIFF
--- a/en/download.htm.template
+++ b/en/download.htm.template
@@ -123,7 +123,7 @@
             that they always contain the most recent changes in the system and can, 
             therefore, be unstable. All files are compressed with 
             <a href='http://www.7-zip.org' target='_blank'>7zip</a>.
-            <b>KolibriOS</b> is distributed under under 
+            <b>KolibriOS</b> is distributed under 
             <a href='http://www.gnu.org/licenses/gpl-2.0.html' target='_blank'>GPLv2</a>
             license, its source code is available on our 
             <a href='https://git.kolibrios.org'>Git server</a>.
@@ -143,15 +143,16 @@
         <div id="carousel"></div>
         <div id="dots"></div>
     </div>
-    
+
     <div id="footer">
-        <img src="../i/logo.png" />
+        <img src="../i/logo.png" alt="KolibriOS Logo" />
         <p>
             &copy; 2004<script>document.write("&thinsp;&ndash;&thinsp;" + new Date().getFullYear());</script>
             <br>
             KolibriOS Team
         </p>
     </div>
+
 </body>
 
 </html>

--- a/en/index.htm
+++ b/en/index.htm
@@ -71,7 +71,7 @@
             It requires only a few megabyte disk space and 12 MB of RAM to run,
             but features a rich set of applications that include word processor, image
             viewer, graphical editor, web browser and over 30 exciting games.
-            It also has full FAT12/16/32 support is implemented, as well as read-only
+            Full FAT12/16/32 support is also implemented, as well as read-only
             support for NTFS, exFAT, ISO9660 and Ext2/3/4 and boasts an extensive set of
             <a href="http://wiki.kolibrios.org/wiki/Hardware_Support">drivers</a>
             for popular sound, network and graphics cards.
@@ -108,16 +108,16 @@
 
         <p class="p-socials">
             <a href="https://t.me/kolibrios_news" target="_blank">
-                <img src="../i/i_telegram.png" />Telegram
+                <img src="../i/i_telegram.png" alt="Telegram" />Telegram
             </a>
             <a href="https://discord.com/invite/FeB2NvE6bF" target="_blank">
-                <img src="../i/i_discord.png" />Discord
+                <img src="../i/i_discord.png" alt="Discord" />Discord
             </a>
             <a href="https://www.facebook.com/groups/kolibrios/" target="_blank">
-                <img src="../i/i_facebook.png" />Facebook
+                <img src="../i/i_facebook.png" alt="Facebook" />Facebook
             </a>
             <a href="https://www.reddit.com/r/KolibriOS/" target="_blank">
-                <img src="../i/i_reddit.png" />Reddit
+                <img src="../i/i_reddit.png" alt="Reddit" />Reddit
             </a>
         </p>
 


### PR DESCRIPTION
Fixed the following issues in the English pages:

- en/index.htm: Fixed broken grammar ("It also has full FAT12/16/32 
  support is implemented" → "Full FAT12/16/32 support is also implemented")
- en/index.htm: Added missing alt attributes on social icons 
  (Telegram, Discord, Facebook, Reddit)
- en/download.htm.template: Removed duplicate word ("under under" → "under")
- en/download.htm.template: Added missing alt attribute on footer logo